### PR TITLE
test(login): add location search to spec

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -133,7 +133,7 @@ import { createMachine } from 'xstate'
 import KongAuthApi from '@/services/kauth-api-client/v1/KongAuthApi'
 import { AuthenticateAuthenticateRequest, EmailverificationsVerifyResponse } from '@/services/kauth-api-client/v1/api'
 import { AxiosResponse } from 'axios'
-import { helpText } from '@/utils'
+import { win, helpText } from '@/utils'
 import useIdentityProvider from '@/composables/useIdentityProvider'
 // Components
 import KAlert from '@kongponents/kalert'
@@ -397,7 +397,8 @@ export default defineComponent({
 
     onMounted(async () => {
       // Get URL params
-      const urlParams = new URLSearchParams(window.location.search)
+      const searchParams = win.getLocationSearch()
+      const urlParams = new URLSearchParams(searchParams)
 
       // If token in URL params
       const token = urlParams?.get('token')

--- a/src/elements/kong-auth-login/KongAuthLogin.spec.ts
+++ b/src/elements/kong-auth-login/KongAuthLogin.spec.ts
@@ -3,6 +3,7 @@
 
 import { mount } from '@cypress/vue'
 import KongAuthLogin from '@/elements/kong-auth-login/KongAuthLogin.ce.vue'
+import { win } from '@/utils'
 
 // Component data-testid strings
 const testids = {
@@ -17,6 +18,9 @@ const testids = {
   registerHelpText: 'kong-auth-login-register-help-text',
   injectedStyles: 'kong-auth-injected-styles',
 }
+
+const userEmail = 'user1@email.com'
+const userPassword = 'TestPassword1!'
 
 describe('KongAuthLogin.ce.vue', () => {
   // Required for all Custom Elements
@@ -76,7 +80,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.errorMessage).should('not.exist')
 
     // Only type an email
-    cy.getTestId(testids.email).type('user1@email.com')
+    cy.getTestId(testids.email).type(userEmail)
 
     // Submit
     cy.getTestId(testids.form).submit()
@@ -92,8 +96,8 @@ describe('KongAuthLogin.ce.vue', () => {
       statusCode: 200,
     }).as('login-request')
 
-    cy.getTestId(testids.email).type('user1@email.com')
-    cy.getTestId(testids.password).type('TestPassword1!')
+    cy.getTestId(testids.email).type(userEmail)
+    cy.getTestId(testids.password).type(userPassword)
     cy.getTestId(testids.form).submit()
 
     cy.wait('@login-request').then(() => {
@@ -192,5 +196,13 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.registerLink).click().then(() => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'click-register-link')
     })
+  })
+
+  it('fills the email input using search params', () => {
+    cy.stub(win, 'getLocationSearch').returns(`?email=${userEmail}`)
+
+    mount(KongAuthLogin)
+
+    cy.getTestId(testids.email).should('have.value', userEmail)
   })
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import registerCustomElement from '@/utils/registerCustomElement'
 import kebabize from '@/utils/kebabize'
 import helpText from '@/utils/helpText'
+import win from '@/utils/window'
 
-export { registerCustomElement, kebabize, helpText }
+export { registerCustomElement, kebabize, helpText, win }

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,0 +1,7 @@
+const win = {
+  getLocationSearch: (): string => {
+    return window.location.search
+  },
+}
+
+export default win


### PR DESCRIPTION
## Summary

So, you can't stub the search property of the window.location object... or properties in general.

What you CAN do is use a function to retrieve window.location.search and then stub that function.

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->

### Notable Changes

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
