### PR TITLE
fix(email-verification): show loader while verifying [KHCP-2602]

### DIFF
--- a/dev/serve-components/ComponentsApp.vue
+++ b/dev/serve-components/ComponentsApp.vue
@@ -91,6 +91,7 @@ body {
   }
 
   .component-container {
+    position: relative;
     background: #fff;
     border: 1px dotted #1155cb;
     margin: 20px;

--- a/dev/serve-elements/ElementsApp.vue
+++ b/dev/serve-elements/ElementsApp.vue
@@ -86,6 +86,7 @@ body {
   }
 
   .component-container {
+    position: relative;
     background: #fff;
     border: 1px dotted #1155cb;
     margin: 20px;

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,6 +1,6 @@
 <template>
   <KSkeleton
-    v-if="currentState.matches('from_url')"
+    v-if="currentState.matches('from_url') || currentState.matches('verify_email')"
     class="idp-loading"
     type="fullscreen-kong"
     :delay-milliseconds="0"
@@ -221,6 +221,7 @@ export default defineComponent({
             on: {
               FROM_REGISTER: 'from_register',
               FROM_URL: 'from_url',
+              VERIFY_EMAIL: 'verify_email',
               CONFIRMED_EMAIL: 'confirmed_email',
               RESET_PASSWORD: 'reset_password',
               SUBMIT_LOGIN: 'pending',
@@ -248,6 +249,13 @@ export default defineComponent({
           from_url: {
             on: {
               IDP_PARAMS: 'pending',
+              REJECT: 'error',
+            },
+          },
+          verify_email: {
+            on: {
+              RESOLVE: 'idle',
+              SUBMIT_LOGIN: 'pending',
               REJECT: 'error',
             },
           },
@@ -296,6 +304,11 @@ export default defineComponent({
 
     const verifyEmailAddress = async (token: string): Promise<void> => {
       try {
+        send('VERIFY_EMAIL')
+
+        // setTimeout for simulated feedback
+        await new Promise((resolve) => setTimeout(resolve, 250))
+
         const response: AxiosResponse<EmailverificationsVerifyResponse> = await $api.emailVerification.verifyEmail({
           token,
         })

--- a/src/elements/kong-auth-login/KongAuthLogin.spec.ts
+++ b/src/elements/kong-auth-login/KongAuthLogin.spec.ts
@@ -122,7 +122,7 @@ describe('KongAuthLogin.ce.vue', () => {
 
   describe('Respond to URL Parameters', () => {
     it('pre-populates the email input from search params', () => {
-    // Stub search params
+      // Stub search params
       cy.stub(win, 'getLocationSearch').returns(`?email=${encodeURIComponent(user.email)}`)
 
       mount(KongAuthLogin)
@@ -132,7 +132,7 @@ describe('KongAuthLogin.ce.vue', () => {
     })
 
     it("should verify email and emit 'confirm-email-success' event if query params include 'token'", () => {
-    // Stub search params
+      // Stub search params
       cy.stub(win, 'getLocationSearch').returns('?token=12345')
 
       cy.intercept('PATCH', '**/email-verifications', {
@@ -146,11 +146,18 @@ describe('KongAuthLogin.ce.vue', () => {
 
       const eventName = 'confirm-email-success'
 
+      // Loader should show on load
+      cy.getTestId(testids.gruceLoader).should('exist').find('.fullscreen-loading-container').should('be.visible')
+
       cy.wait('@email-verification-request').then(() => {
+        // Verify UI
+        cy.getTestId(testids.gruceLoader).should('not.exist')
         cy.getTestId(testids.confirmedEmailMessage).should('be.visible').should('contain.text', helpText.login.confirmedEmailSuccess)
+        cy.getTestId(testids.email).should('have.value', user.email)
+
         // Check for emitted event
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', eventName).then(() => {
-        // Verify emit payload
+          // Verify emit payload
           cy.wrap(Cypress.vueWrapper.emitted(eventName)[0][0]).should('have.property', 'email')
         })
       })


### PR DESCRIPTION
## Summary
UI should show loading state while email-verification call is being sent to prevent user from trying to log in before their email is verified.
<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->

### Notable Changes

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [x] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
