### PR TITLE
fix(register): access code requirement from prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ To respond to any of the emitted events in your app, simply provide a callback f
 
 | Prop              | Type   | Default | Description                                                |
 | :---------------- | :----- | :------ | :--------------------------------------------------------- |
+| `accessCodeRequired` | Boolean | `false`    | An access code is required for registration. |
 | `instructionText` | String | `''`    | Set the instruction text to display above the form inputs. |
 | `showPasswordStrengthMeter` | Boolean | `false`    | Show the password strength meter. |
 

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -175,6 +175,7 @@ export default defineComponent({
   setup(props, { emit }) {
     // Get custom element props. If set up properly, these should be refs, meaning you can access them in the setup() with {variable-name}.value
     // The default values provided to inject() here should be refs with empty/false since the defaults are typically handled in the custom element provide()
+    const accessCodeRequired: Ref<boolean> = inject('access-code-required', ref(false)) // False by default so the backend can guard registration
     const instructionText: Ref<string> = inject('instruction-text', ref(''))
     const showPasswordStrengthMeter: Ref<boolean> = inject('show-password-strength-meter', ref(false))
 
@@ -189,7 +190,6 @@ export default defineComponent({
       checked_agreement: false,
     })
 
-    const accessCodeRequired = ref(false) // False by default so the backend can guard registration
     const error = ref<any>(null)
     const passwordError = ref<boolean>(false)
     const fieldsHaveError = ref(false)
@@ -301,20 +301,7 @@ export default defineComponent({
       }
     }
 
-    const checkForAccessCodeRequirement = async (): Promise<void> => {
-      try {
-        // Check if access code is required
-        const clientConfigResponse = await $api.clientConfig.clientConfig()
-        accessCodeRequired.value = clientConfigResponse?.data?.requireRegistrationAccessCode === true
-      } catch (_) {
-        // Set to false in case of error and let the backend guard Registration
-        accessCodeRequired.value = false
-      }
-    }
-
     onMounted(async () => {
-      await checkForAccessCodeRequirement()
-
       const urlParams: URLSearchParams = new URLSearchParams(win.getLocationSearch())
 
       formData.emailToken = urlParams?.get('token') || ''

--- a/src/elements/kong-auth-register/KongAuthRegister.ce.vue
+++ b/src/elements/kong-auth-register/KongAuthRegister.ce.vue
@@ -16,6 +16,7 @@ export default defineComponent({
 
   // Props are defined here for use on the custom element tag
   props: {
+    accessCodeRequired: Boolean,
     instructionText: String,
     showPasswordStrengthMeter: Boolean,
   },
@@ -30,6 +31,10 @@ export default defineComponent({
 
   setup(props) {
     // Provide custom element props to child components
+    provide(
+      'access-code-required',
+      computed((): boolean => (props.accessCodeRequired ? props.accessCodeRequired : false)),
+    )
     provide(
       'instruction-text',
       computed((): string => (props.instructionText ? props.instructionText : '')),


### PR DESCRIPTION
## Summary

Get the `accessCodeRequired` value from a prop instead of hitting the `/client-config` endpoint.

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->

### Notable Changes

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [x] **Tests:** Includes any new/updated component tests
- [x] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
