### PR TITLE
feat(styles): allow passing array of inlined css to shadow root

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const options: KongAuthElementsOptions = {
   apiBaseUrl: '/kauth',
   userEntity: 'user',
   shadowDom: true,
-  shadowDomCss: ['./dist/style.css'],
+  shadowDomCss: ['.kong-auth-login-form .k-input#email { background-color: var(--red-400, #ff0000) }'],
 }
 
 // Call the registration function to automatically register all custom elements for usage
@@ -119,7 +119,27 @@ Regardless if you're using in Vue 3, Vue 2, or the native web components, an ide
 | `apiBaseUrl` | `string` | `/kauth` | The `basePath` of the internal `axios` instance. <br><br>Unless using an absolute URL, this base path **must** start with a leading slash (if setting the default) in order to properly resolve within container applications, especially when called from nested routes(e.g. /organizations/users) |
 | `userEntity` | `string` | `user` | The user entity for authentication; one of `user` or `developer`. |
 | `shadowDom` | `boolean` | `false` | Automatically register the elements as native web components (forced to `true` if using the `registerKongAuthNativeElements` function). |
-| `shadowDomCss` | `Array<string>` | `[]` | If `shadowDom` is set to `true`, you can also pass an array of CSS stylesheet URLs to load into the shadow DOM for each of the native web components. |
+| `shadowDomCss` | `string[]` | `[]` | If `shadowDom` is set to `true`, you can pass an array of inlined CSS strings that will be added to the shadow root of all elements. [See the example below](#shadow-dom-css) |
+
+#### Shadow DOM CSS
+
+```ts
+// Pass in inlined CSS strings as needed
+
+const pluginOptions: KongAuthElementsOptions = {
+  apiBaseUrl: '/kauth',
+  userEntity: 'user',
+  shadowDomCss: [
+    '.kong-auth-login-form .k-input#email { background-color: var(--red-400, #ff0000) }',
+    `
+    .kong-auth-register-form .k-input {
+      width: 50%;
+    }
+    `,
+  ],
+}
+```
+
 
 You can import the `KongAuthElementsOptions` interface from the package if you're using TypeScript.
 

--- a/src/composables/useInjectStyles.ts
+++ b/src/composables/useInjectStyles.ts
@@ -11,26 +11,25 @@ export default function useInjectStyles(): InjectStylesComposable {
   const injectedStyles = computed((): string => {
     let styles = ''
 
-    // If building
-    if (import.meta.env.PROD) {
-      // If an array of CSS links were passed, iterate through array
-      if (typeof shadowDomCss === 'object' && shadowDomCss?.length) {
-        for (const href in shadowDomCss) {
-          // Add to the shadow DOM
-          styles += `<link href="${shadowDomCss[href]}" rel="stylesheet"/>`
-        }
-      } else if (shadowDomCss && typeof shadowDomCss === 'string') {
-        // Provide a fallback in case they passed a CSS link as a string
-        // Add to the shadow DOM
-        styles += `<link href="${shadowDomCss}" rel="stylesheet"/>`
-      }
-    }
+    if (!shadowDom) return styles
 
     // If shadow DOM and inlineStyles has value
     if (shadowDom && inlineStyles.value && inlineStyles.value.length) {
       styles += `<style type="text/css">${inlineStyles.value
         .map((styleNode: HTMLElement) => styleNode.innerHTML)
         .join('')}</style>`
+    }
+
+    // If an array of CSS links were passed, iterate through array
+    if (typeof shadowDomCss === 'object' && shadowDomCss?.length) {
+      for (const css in shadowDomCss) {
+        // Add to the shadow DOM
+        styles += String(shadowDomCss[css]).trim().length && `<style type="text/css" data-testid="shadow-dom-css-${css}">${String(shadowDomCss[css]).trim()}</style>`
+      }
+    } else if (shadowDomCss && typeof shadowDomCss === 'string') {
+      // Provide a fallback in case they passed a CSS link as a string
+      // Add to the shadow DOM
+      styles += String(shadowDomCss).trim().length && `<style type="text/css" data-testid="shadow-dom-css-0">${String(shadowDomCss).trim()}</style>`
     }
 
     return styles


### PR DESCRIPTION
## Summary

Pass an array of inlined CSS strings to the shadow root of all elements.

```ts
// Pass in inlined CSS strings as needed

const pluginOptions: KongAuthElementsOptions = {
  apiBaseUrl: '/kauth',
  userEntity: 'user',
  shadowDomCss: [
    '.kong-auth-login-form .k-input#email { background-color: var(--red-400, #ff0000) }',
    `
    .kong-auth-register-form .k-input {
      width: 50%;
    }
    `,
  ],
}
```

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->

### Notable Changes

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
