### PR TITLE
fix(basic-auth): prop should resolve as boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Wherever you want to utilze a custom element, [you **must** wrap it with an elem
 ```html
 <div id="kong-auth-login-wrapper">
   <kong-auth-login
+    basic-auth-login-enabled
     show-forgot-password-link
     @login-success="onLoginSuccess"
     @click-forgot-password-link="onUserClickForgotPassword"
@@ -414,7 +415,7 @@ The login element **must** reside at the `{window.location.origin}/login` path i
 | `registerLinkHelpText` | String  | `Don't have an account?`   | Set the register link help text. |
 | `registerLinkText` | String  | `Sign Up` | Set the text for the register link. |
 | `registerSuccessText` | String  | `Successfully registered!` | Set the text for the register success message. |
-| `basicAuthLoginEnabled` | Boolean | `true` | Enable basic auth login. |
+| `basicAuthLoginEnabled` | Boolean | `false` | Enable basic auth login. |
 | `idpLoginEnabled` | Boolean | `false` | Enable IdP login detection. |
 | `idpLoginReturnTo` | URL | `''` | Set the URL to return to upon successful IdP login. In most cases, this should be set to `window.location.origin` |
 

--- a/dev/serve-components/ComponentsApp.vue
+++ b/dev/serve-components/ComponentsApp.vue
@@ -10,7 +10,7 @@
         <div id="kong-auth-login-wrapper">
           <KongAuthLogin
             wrapper-id="kong-auth-login-wrapper"
-            :basic-auth-login-enabled="true"
+            basic-auth-login-enabled
             :idp-login-enabled="true"
             idp-login-return-to="https://kompany795bb6b9.us.portal.konghq.tech"
             show-forgot-password-link

--- a/dev/serve-elements/ElementsApp.vue
+++ b/dev/serve-elements/ElementsApp.vue
@@ -10,6 +10,7 @@
         <div id="kong-auth-login-wrapper">
           <kong-auth-login
             wrapper-id="kong-auth-login-wrapper"
+            :basicAuthLoginEnabled="true"
             idp-login-enabled
             idp-login-return-to="https://hydrogen.ephemeral.konnect-dev.konghq.com/"
             show-forgot-password-link

--- a/dev/serve-elements/index.ts
+++ b/dev/serve-elements/index.ts
@@ -8,7 +8,7 @@ const app = createApp(ElementsApp)
 const options: KongAuthElementsOptions = {
   // Unless using an absolute URL, this base path MUST start with a leading slash (if setting the default) in order to properly resolve within container applications, especially when called from nested routes(e.g. /organizations/users)
   apiBaseUrl: '/kauth',
-  userEntity: 'developer',
+  userEntity: 'user',
   shadowDom: false,
   developerConfig: {
     portalId: 'dfc77af7-ba97-4c52-889e-b2ca75b51ed3',

--- a/src/elements/kong-auth-login/KongAuthLogin.ce.vue
+++ b/src/elements/kong-auth-login/KongAuthLogin.ce.vue
@@ -59,7 +59,7 @@ export default defineComponent({
     },
     basicAuthLoginEnabled: {
       type: Boolean,
-      default: true,
+      default: false, // must be false by default
     },
     idpLoginEnabled: {
       type: Boolean,


### PR DESCRIPTION
## Summary

Set `basicAuthLoginEnabled` prop to `false` by default; also resolves the prop to a `boolean` instead of a `string`

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->


<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [x] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
