### PR TITLE
feat: new builds without vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ yarn add @kong/kong-auth-elements
 
 ### CDN
 
-We also provide a `kong-auth-elements.global-vue.umd.js` UMD bundle that does **NOT** internalize (bundle) the Vue core along with it. This UMD bundle can can be imported via `<script>` tag to import the lib into projects where Vue is already available in the global namespace.
+The default exports have a bundle filename of `*.vue.{umd|es}.js` where we internalize Vue for consumption by the plugin (i.e. the bundle includes the Vue core).
+
+We also provide `kong-auth-elements.{umd|es}.js` bundles that do **NOT** internalize (bundle) the Vue core along with it. These bundles can can be imported via `<script>` (`umd` bundle) or `<script type="module">` (`es` bundle) tags into projects where Vue is already available in the global namespace.
 
 To utilize, include the script tag on your page after including Vue, and then call `window.registerKongAuthNativeElements()` with the [options](#options) outlined below.
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@kong/kong-auth-elements",
   "version": "0.0.0-development",
-  "main": "dist/kong-auth-elements.umd.js",
-  "module": "dist/kong-auth-elements.es.js",
+  "main": "dist/kong-auth-elements.vue.umd.js",
+  "module": "dist/kong-auth-elements.vue.es.js",
   "exports": {
     ".": {
-      "import": "./dist/kong-auth-elements.es.js",
-      "require": "./dist/kong-auth-elements.umd.js"
+      "import": "./dist/kong-auth-elements.vue.es.js",
+      "require": "./dist/kong-auth-elements.vue.umd.js"
     },
     "./dist/style.css": "./dist/style.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,28 +15,26 @@ export default ({ mode }) => {
 
   return defineConfig({
     build: {
-      // If INCLUDE_VUE=no, do not empty the dist folder on build
-      emptyOutDir: process.env.INCLUDE_VUE !== 'no',
+      // If INCLUDE_VUE=yes, do not empty the dist folder on build
+      emptyOutDir: process.env.INCLUDE_VUE === 'yes',
       lib: {
         name: 'kong-auth-elements',
-        // If INCLUDE_VUE=no, only output UMD
-        formats: process.env.INCLUDE_VUE === 'no' ? ['umd'] : ['es', 'umd'],
         entry: path.resolve(__dirname, 'src/index.ts'),
-        // If INCLUDE_VUE=no, add `global-vue.` in the filename
-        fileName: (format) => `kong-auth-elements.${process.env.INCLUDE_VUE === 'no' ? 'global-vue.' : ''}${format}.js`,
+        // If INCLUDE_VUE=yes, add `vue.` in the filename
+        fileName: (format) => `kong-auth-elements.${process.env.INCLUDE_VUE === 'yes' ? 'vue.' : ''}${format}.js`,
       },
       cssCodeSplit: false,
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled into your library
         // Only enable to utilize as a Vue 3 Plugin
-        // If INCLUDE_VUE=no, externalize Vue (for Kong/ui-shared-components)
-        external: process.env.INCLUDE_VUE === 'no' ? ['vue'] : undefined,
+        // If INCLUDE_VUE=yes, externalize Vue (for Kong/ui-shared-components)
+        external: process.env.INCLUDE_VUE === 'yes' ? undefined : ['vue'],
         output: {
           exports: 'named',
           // Provide global variables to use in the UMD build for externalized deps
           // Enable to utilize consuming app's vue instance
-          // If INCLUDE_VUE=no, provide global Vue
-          globals: process.env.INCLUDE_VUE === 'no' ? { vue: 'Vue' } : undefined,
+          // If INCLUDE_VUE=yes, provide global Vue
+          globals: process.env.INCLUDE_VUE === 'yes' ? undefined : { vue: 'Vue' },
         },
       },
     },


### PR DESCRIPTION
## Summary

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->

Changes the default bundle exports to include `*.vue.{umd|es}.js`, e.g. `/dist/kong-auth-elements.vue.umd.js` for the bundles that internalize (bundle) `Vue`.

This PR also adds new builds that externalize Vue, meaning Vue is no longer packaged along with the lib and instead it depends on the host application to make `Vue` available globally.


<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
