### PR TITLE
feat(login-form): utilize the generic spinner loader if entity is developer (TDX-2940)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@cypress/vite-dev-server": "^5.0.4",
     "@cypress/vue": "^4.2.2",
     "@digitalroute/cz-conventional-changelog-for-jira": "^7.5.1",
-    "@kong/kongponents": "^8.33.2",
+    "@kong/kongponents": "^8.36.0",
     "@rushstack/eslint-patch": "^1.2.0",
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/git": "^10.0.1",
@@ -91,7 +91,7 @@
     "zxcvbn": "^4.4.2"
   },
   "peerDependencies": {
-    "@kong/kongponents": "^8.33.2",
+    "@kong/kongponents": "^8.36.0",
     "axios": "^0.27.2",
     "vue": "^3.2.47"
   },

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -5,7 +5,7 @@
       class="idp-loading"
       data-testid="kong-auth-login-gruce-loader"
       :delay-milliseconds="0"
-      type="fullscreen-kong"
+      :type="userEntity === 'developer' ? 'fullscreen-generic' : 'fullscreen-kong'"
     />
 
     <div v-else>

--- a/src/elements/kong-auth-login/KongAuthLogin.spec.ts
+++ b/src/elements/kong-auth-login/KongAuthLogin.spec.ts
@@ -26,7 +26,9 @@ const testids = {
   passwordResetMessage: 'kong-auth-login-password-reset-message',
   confirmedEmailMessage: 'kong-auth-login-confirmed-email-message',
   registerSuccessMessage: 'kong-auth-login-register-success-message',
-  gruceLoader: 'kong-auth-login-gruce-loader',
+  loaderContainer: 'kong-auth-login-gruce-loader',
+  gruceLoader: 'full-screen-loader',
+  genericSpinnerLoader: 'full-screen-spinner-loader',
 }
 
 const user = {
@@ -70,7 +72,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.passwordResetMessage).should('not.exist')
     cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
     cy.getTestId(testids.registerSuccessMessage).should('not.exist')
-    cy.getTestId(testids.gruceLoader).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
   })
 
   it('renders a login form with email, password, and button elements and no SSO button if basic auth and IdP login is enabled and userEntity is \'user\'', () => {
@@ -101,7 +103,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.passwordResetMessage).should('not.exist')
     cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
     cy.getTestId(testids.registerSuccessMessage).should('not.exist')
-    cy.getTestId(testids.gruceLoader).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
   })
 
   it('renders a login form with email, password, and button elements and a SSO button if basic auth and IdP login is enabled and userEntity is \'developer\'', () => {
@@ -132,7 +134,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.passwordResetMessage).should('not.exist')
     cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
     cy.getTestId(testids.registerSuccessMessage).should('not.exist')
-    cy.getTestId(testids.gruceLoader).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
   })
 
   it('renders a SSO button and no basic auth form if only SSO login is enabled and userEntity = \'user\' and they are at a login path', () => {
@@ -161,7 +163,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.passwordResetMessage).should('not.exist')
     cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
     cy.getTestId(testids.registerSuccessMessage).should('not.exist')
-    cy.getTestId(testids.gruceLoader).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
   })
 
   it('renders a SSO button and no basic auth form if only SSO login is enabled and userEntity = \'developer\'', () => {
@@ -186,7 +188,7 @@ describe('KongAuthLogin.ce.vue', () => {
     cy.getTestId(testids.passwordResetMessage).should('not.exist')
     cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
     cy.getTestId(testids.registerSuccessMessage).should('not.exist')
-    cy.getTestId(testids.gruceLoader).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
   })
 
   it('renders a SSO button and does not display form or basic auth link if only SSO login is enabled and userEntity is developer', () => {
@@ -332,11 +334,11 @@ describe('KongAuthLogin.ce.vue', () => {
       const eventName = 'verify-email-success'
 
       // Loader should show on load
-      cy.getTestId(testids.gruceLoader).should('exist').find('.fullscreen-loading-container').should('be.visible')
+      cy.getTestId(testids.loaderContainer).should('exist').getTestId(testids.gruceLoader).should('be.visible')
 
       cy.wait('@email-verification-request').then(() => {
         // Verify UI
-        cy.getTestId(testids.gruceLoader).should('not.exist')
+        cy.getTestId(testids.loaderContainer).should('not.exist')
         cy.getTestId(testids.confirmedEmailMessage).should('be.visible').and('contain.text', messages.login.confirmedEmailSuccess)
         cy.getTestId(testids.email).should('have.value', user.email)
 
@@ -391,11 +393,11 @@ describe('KongAuthLogin.ce.vue', () => {
       const eventName = 'verify-email-success'
 
       // Loader should show on load
-      cy.getTestId(testids.gruceLoader).should('exist').find('.fullscreen-loading-container').should('be.visible')
+      cy.getTestId(testids.loaderContainer).should('exist').getTestId(testids.genericSpinnerLoader).should('be.visible')
 
       cy.wait('@email-verification-request').then(() => {
         // Verify UI
-        cy.getTestId(testids.gruceLoader).should('not.exist')
+        cy.getTestId(testids.loaderContainer).should('not.exist')
         cy.getTestId(testids.confirmedEmailMessage).should('be.visible').and('contain.text', messages.login.confirmedEmailSuccess)
         cy.getTestId(testids.email).should('have.value', user.email)
 
@@ -483,7 +485,7 @@ describe('KongAuthLogin.ce.vue', () => {
       })
 
       cy.get('@set-location').should('have.been.calledOnce').and('have.been.calledWithMatch', redirectPath)
-      cy.getTestId(testids.gruceLoader).should('exist').find('.fullscreen-loading-container').should('be.visible')
+      cy.getTestId(testids.loaderContainer).should('exist').getTestId(testids.gruceLoader).should('be.visible')
     })
 
     it("should initiate developer IdP login if props are set and URL is '/login/sso'", () => {
@@ -506,7 +508,7 @@ describe('KongAuthLogin.ce.vue', () => {
       })
 
       cy.get('@set-location').should('have.been.calledOnce').and('have.been.calledWithMatch', redirectPath)
-      cy.getTestId(testids.gruceLoader).should('exist').find('.fullscreen-loading-container').should('be.visible')
+      cy.getTestId(testids.loaderContainer).should('exist').getTestId(testids.genericSpinnerLoader).should('be.visible')
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,10 @@
   resolved "https://registry.yarnpkg.com/@kong/kauth-client-typescript-axios/-/kauth-client-typescript-axios-0.1811.0.tgz#8a13df8f9c73628dea0e65fed7963e30ad3456c8"
   integrity sha512-XElk7krbE9NN+6zwSyv8mPj8uUxt8tWWtJcPVhkJjL/3N7o1zdHwDTCeTwYMH9PjMGUbm0Sh8LCVjynH3euSEQ==
 
-"@kong/kongponents@^8.33.2":
-  version "8.33.2"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.33.2.tgz#30c88a28ebdaf8e2379dc0b24c320b8986aa97b4"
-  integrity sha512-UACD2FFoAJlAycp/+xYFreoXyMT6OK0ljO4rEBRtil23YgnemgtI9VlJAxX/nTzhOMq1jCRqkbxEKRt7HxXhtA==
+"@kong/kongponents@^8.36.0":
+  version "8.36.0"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.36.0.tgz#b2062ebcbb8b779d014b19307676ca32a1855bea"
+  integrity sha512-lXj1HBTDs4MTlm5/yTXpemCiKm9rU8ZLSOgC7Tgd6z3M0Az0OWjf86WkdDuDg19djj9x53Xi80JVrUfGJ1wEUQ==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.29.3"


### PR DESCRIPTION
## Summary
This PR makes a change to the `KSkeleton` that is being used. If we are in the developer portal (when `entity === 'developer'`) we want to display a generic spinner screen, instead of the branded gruceo. Tests are also updated as a result of this change.

<!-- Be sure to add the JIRA ticket number to the title of your Pull Request -->


<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
