### PR TITLE
fix(KongAuthChangePassword): add placeholder to all change password inputs [KHCP-6681]

### DIFF
--- a/src/components/ChangePasswordForm.vue
+++ b/src/components/ChangePasswordForm.vue
@@ -25,6 +25,7 @@
         data-testid="kong-auth-change-password-current-password"
         :has-error="currentState.matches('error') && error ? true : false"
         :label="`${convertToTitleCase(messages.inputLabels.currentPassword)} *`"
+        :placeholder="messages.inputLabels.currentPasswordPlaceholder"
         required
         type="password"
       />
@@ -37,6 +38,7 @@
         data-testid="kong-auth-change-password-new-password"
         :has-error="currentState.matches('error') && error ? true : false"
         :label="`${convertToTitleCase(messages.inputLabels.newPassword)} *`"
+        :placeholder="messages.inputLabels.newPasswordPlaceholder"
         required
         type="password"
       />
@@ -50,6 +52,7 @@
         :error-message="passwordIsInvalid ? messages.resetPassword.passwordMismatch : undefined"
         :has-error="(currentState.matches('error') && error) || passwordIsInvalid ? true : false"
         :label="`${convertToTitleCase(messages.inputLabels.confirmPassword)} *`"
+        :placeholder="messages.inputLabels.confirmPasswordPlaceholder"
         required
         type="password"
       />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,8 +68,11 @@
     "password": "Password",
     "accessCode": "Access code",
     "currentPassword": "Current password",
+    "currentPasswordPlaceholder": "Enter your current password",
     "newPassword": "New password",
-    "confirmPassword": "Confirm new password"
+    "newPasswordPlaceholder": "Enter a new password",
+    "confirmPassword": "Confirm new password",
+    "confirmPasswordPlaceholder": "Enter the new password again"
   }
 }
 


### PR DESCRIPTION
…

## Summary

add placeholder to all change password inputs

<img width="536" alt="Screenshot 2023-03-30 at 6 30 50 AM" src="https://user-images.githubusercontent.com/2568272/228852253-9f983333-6092-42c1-bbec-68a98fa6194e.png">

https://konghq.atlassian.net/browse/KHCP-6618

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
