### PR TITLE
fix(changePasswordForm): add refs to ChangePasswordForm for consumer to manipulate [KHCP-6618]

### DIFF
--- a/src/components/ChangePasswordForm.vue
+++ b/src/components/ChangePasswordForm.vue
@@ -19,6 +19,7 @@
 
       <KInput
         id="current-password"
+        ref="currentPassword"
         v-model.trim="formData.currentPassword"
         autocomplete="current-password"
         class="w-100 mb-4"
@@ -32,6 +33,7 @@
 
       <KInput
         id="new-password"
+        ref="newPassword"
         v-model.trim="formData.newPassword"
         autocomplete="new-password"
         class="w-100 mb-4"
@@ -45,6 +47,7 @@
 
       <KInput
         id="password-confirm"
+        ref="passwordConfirm"
         v-model.trim="formData.confirmPassword"
         autocomplete="new-password"
         class="w-100 mb-4"
@@ -59,6 +62,7 @@
 
       <KButton
         id="change-password-submit"
+        ref="changePasswordSubmit"
         appearance="primary"
         class="justify-content-center w-100 type-lg"
         data-testid="kong-auth-change-password-submit"


### PR DESCRIPTION

## Summary

https://konghq.atlassian.net/browse/KHCP-6618

Adds refs to ChangePasswordForm fields for consuming app to manipulate

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
