### PR TITLE
fix: add hidden email fields for a11y [KHCP-6910]

### DIFF
--- a/src/assets/styles/_elements.scss
+++ b/src/assets/styles/_elements.scss
@@ -129,3 +129,7 @@ a {
     color: var(--blue-500);
   }
 }
+
+input.hidden-input {
+  display: none !important;
+}

--- a/src/components/ChangePasswordForm.vue
+++ b/src/components/ChangePasswordForm.vue
@@ -17,6 +17,9 @@
         data-testid="kong-auth-change-password-instruction-text"
       >{{ instructionText }}</p>
 
+      <!-- Hidden username input to assist password managers -->
+      <input id="email" autocomplete="username" class="hidden-input" name="email" type="email" />
+
       <KInput
         id="current-password"
         ref="currentPassword"

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -87,7 +87,7 @@
             id="email"
             v-model.trim="formData.email"
             autocapitalize="off"
-           autocomplete="username"
+            autocomplete="username"
             class="w-100 mb-5"
             data-testid="kong-auth-login-email"
             :has-error="currentState.matches('error') && error && fieldsHaveError ? true : false"

--- a/src/components/ResetPasswordForm.vue
+++ b/src/components/ResetPasswordForm.vue
@@ -18,7 +18,7 @@
       >{{ instructionText }}</p>
 
       <!-- Hidden username input to assist password managers -->
-      <input id="email" autocomplete="username" name="email" type="hidden" />
+      <input id="email" autocomplete="username" class="hidden-input" name="email" type="email" />
 
       <KInput
         id="password"


### PR DESCRIPTION
## Summary

Add a hidden email field for a11y support on the change password form.


<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
