### PR TITLE
fix:  only do PR preview steps when test is executed from PR flow [KHCP-6878]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
 
       - name: Remove preview consumption comment
+        if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr_preview_consumption
@@ -75,6 +76,7 @@ jobs:
           path: cypress/screenshots/
 
       - name: Build
+        if: github.event_name == 'pull_request'
         run: yarn build
 
       - name: Upload Cypress videos (always)


### PR DESCRIPTION
## Summary

test workflow is executed from `publish` on commit to main. At that stage we do not need to deal with PR previews or comments