### PR TITLE
fix(changePassword): move error message element from top to bottom [KHCP-6618]

### DIFF
--- a/src/components/ChangePasswordForm.vue
+++ b/src/components/ChangePasswordForm.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="kong-auth-change-password-form">
-    <div v-if="currentState.matches('error') && error" class="my-4">
-      <ErrorMessage :error="error" />
-    </div>
-
     <form
       v-if="!currentState.matches('success')"
       class="change-password-form"
@@ -62,6 +58,10 @@
         required
         type="password"
       />
+
+      <div v-if="currentState.matches('error') && error" class="my-4">
+        <ErrorMessage :error="error" />
+      </div>
 
       <div class="action-buttons">
         <KButton


### PR DESCRIPTION
## Summary

move error message element from top to bottom in ChangePasswordForm

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
