### PR TITLE
fix(changePasswordForm): disable the update button until password criterias are met [KHCP-6958]

### DIFF
--- a/src/components/ChangePasswordForm.vue
+++ b/src/components/ChangePasswordForm.vue
@@ -149,6 +149,12 @@ const passwordRequirementsMet = {
   special: computed((): boolean => atLeast1SpecialCharRegex.test(formData.newPassword)),
 }
 
+// a password is considered valid if it meets at least 3 out of the above 4 password requirements
+const arePasswordRequirementsMet = computed((): boolean => Object.values(passwordRequirementsMet).filter(requirement => requirement.value === true).length >= 3)
+
+// password must be at least 8 characters long and no more than 128 characters long
+const isPasswordRequiredLength = computed((): boolean => formData.newPassword.length >= 8 && formData.newPassword.length <= 128)
+
 const error = ref<any>(null)
 const passwordError = ref<boolean>(false)
 
@@ -177,17 +183,14 @@ const passwordIsInvalid = computed((): boolean => formData.newPassword !== formD
 const btnText = computed((): string => ['pending', 'success'].some(currentState.value.matches) ? messages.resetPassword.submittingText : changePasswordButtonText.value)
 
 const btnDisabled = computed((): boolean => {
-  const countRequirementsMet = Object.values(passwordRequirementsMet).filter(val => val.value === true).length
-
   return (
     currentState.value.matches('pending') ||
       !formData.currentPassword ||
       !formData.newPassword ||
       !formData.confirmPassword ||
       passwordIsInvalid.value ||
-      countRequirementsMet < 3 ||
-      formData.newPassword.length < 8 ||
-      formData.newPassword.length > 128
+      !arePasswordRequirementsMet.value ||
+      !isPasswordRequiredLength.value
   )
 })
 


### PR DESCRIPTION

## Summary

https://konghq.atlassian.net/browse/KHCP-6958

* If 3 out of 4 bullet point requirements are met, we will enable the Update button, or else it will be disabled.
* We will disable the Update button if the password length requirement is not met.

<!--
Be sure to include any changes that might require additional context or backstory to aid with reviewing. Always have in mind that we review PR's months or years later, so the more detailed the better.
Include any information on how best to test the changes, but do not be overly prescriptive on how to test to minimize [anchoring bias](https://en.wikipedia.org/wiki/Anchoring_(cognitive_bias)).
-->

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
