### PR TITLE
chore: catch and fail CI when PR preview publishing fails [KHCP-7061]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version  --yes --amend
 
           npm_instructions=""
-          rm .npmrc
+
           pkg=$(npm publish  --no-git-checks --access restricted --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')
 
           if [[ -z "${pkg}" ]]; then


### PR DESCRIPTION
## Summary

When PR preview package publish fail - fail entire CI of PR. 


![image](https://user-images.githubusercontent.com/4562608/233173948-b709412f-0a54-4f54-bdc5-90704ea379f9.png)


