### PR TITLE
chore: publish PR preview package without waiting for CY tests [KHCP-7291]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,11 +49,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
 
-      - name: Trigger a build for packages.konghq.tech
-        if: ${{ success() }}
-        run: |
-          curl -X POST \
-              -H 'Accept: application/vnd.github.everest-preview+json' \
-              -H  'Content-Type: application/json' \
-              -H 'Authorization: token ${{ secrets.KONGPONENTS_BOT_PAT }}' \
-              --data '{"event_type": "webhook"}' https://api.github.com/repos/Kong/package-publisher/dispatches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,31 +54,9 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
-      - name: Run Cypress component tests
-        uses: cypress-io/github-action@v5
-        with:
-          install: false
-          command: yarn test
-        env:
-          VITE_AUTH_URL: ${{ secrets.VITE_AUTH_URL || inputs.VITE_AUTH_URL }}
-
-      - name: Upload Cypress screenshots (on failure)
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress_screenshots
-          path: cypress/screenshots/
-
       - name: Build
         if: github.event_name == 'pull_request'
         run: yarn build
-
-      - name: Upload Cypress videos (always)
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress_videos
-          path: cypress/videos/
 
       - name: Create .npmrc
         env:
@@ -130,3 +108,24 @@ jobs:
              ```
           GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
+      - name: Run Cypress component tests
+        uses: cypress-io/github-action@v5
+        with:
+          install: false
+          command: yarn test
+        env:
+          VITE_AUTH_URL: ${{ secrets.VITE_AUTH_URL || inputs.VITE_AUTH_URL }}
+
+      - name: Upload Cypress screenshots (on failure)
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress_screenshots
+          path: cypress/screenshots/
+
+      - name: Upload Cypress videos (always)
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress_videos
+          path: cypress/videos/


### PR DESCRIPTION
## Summary

also removing step of published to packages.konghq.tech - we do not do it as of yet. this site never was even moved from netlify. and it is not needed for public package anyways. 