### PR TITLE
fix: do not publish already published PR version [KHCP-7476]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,15 @@ jobs:
 
           yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version --yes --amend
 
+          package_version=$(jq -r ".version" package.json)
+          package=@kong/kong-auth-elements@"${package_version}"
+
+          npm show "${package}" >/dev/null 2>&1 && npm_show_status=0 || npm_show_status=1
+          if [ $npm_show_status -eq 0 ]; then
+            echo "Package ${package} is already published. Skipping publishing."
+            exit 0
+          fi
+
           npm_instructions=""
 
           pkg=$(npm publish --no-git-checks --access public --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')


### PR DESCRIPTION
## Summary

Allowed re-run workflow without attempting to re-publish already published