### PR TITLE
feat(login): allow hiding basic auth link [KHCP-8307]

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ The login element **must** reside at the `{window.location.origin}/login` path i
 | `registerLinkText` | String  | `Sign Up` | Set the text for the register link. |
 | `registerSuccessText` | String  | `Successfully registered!` | Set the text for the register success message. |
 | `basicAuthLoginEnabled` | Boolean | `false` | Enable basic auth login. **To set to false, simply do not add the prop** |
+| `showBasicAuthLoginLink` | Boolean | `true` | Show a link to log in with basic auth credentials on the IdP login form. |
 | `idpLoginEnabled` | Boolean | `false` | Enable IdP login detection. |
 | `idpLoginReturnTo` | URL | `''` | Set the URL to return to upon successful IdP login. In most cases, this should be set to `window.location.origin` |
 

--- a/sandbox/shared/router.ts
+++ b/sandbox/shared/router.ts
@@ -13,6 +13,15 @@ const pageRoutes = [
 const routes: RouteRecordRaw[] = []
 
 pageRoutes.forEach((routePath: string) => {
+  if (routePath === 'login') {
+    routes.push({
+      path: '/login/:login_path?',
+      name: routePath,
+      component: PageView,
+    })
+    return
+  }
+
   routes.push({
     path: routePath,
     name: routePath,

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -188,6 +188,7 @@ const registerLinkText: Ref<string> = inject('register-link-text', ref(messages.
 const registerLinkHelpText: Ref<string> = inject('register-link-help-text', ref(messages.login.registerLinkHelpText))
 const registerSuccessText: Ref<string> = inject('register-success-text', ref(messages.login.registerSuccess))
 const basicAuthLoginEnabled: Ref<boolean> = inject('basic-auth-login-enabled', ref(true))
+const showBasicAuthLoginLink: Ref<boolean> = inject('show-basic-auth-login-link', ref(true))
 const idpLoginEnabled: Ref<boolean> = inject('idp-login-enabled', ref(false))
 const idpLoginReturnTo: Ref<string> = inject('idp-login-return-to', ref(''))
 
@@ -198,7 +199,7 @@ const formData = reactive({
 const error = ref<any>(null)
 const fieldsHaveError = ref(false)
 const forceBasicAuth = ref(false)
-const loginWithCredentialsLinkIsVisible = computed((): boolean => userEntity !== 'developer' && !basicAuthLoginEnabled.value && !forceBasicAuth.value)
+const loginWithCredentialsLinkIsVisible = computed((): boolean => userEntity !== 'developer' && !basicAuthLoginEnabled.value && !forceBasicAuth.value && showBasicAuthLoginLink.value)
 const loginDividerIsVisible = computed((): boolean => (basicAuthLoginEnabled.value && idpLoginEnabled.value && (userEntity === 'developer' || (userEntity === 'user' && isIdpLogin.value))) || forceBasicAuth.value)
 
 // Setup and automatically trigger IDP (or ignore it, depending on the props)

--- a/src/elements/kong-auth-login/KongAuthLogin.ce.vue
+++ b/src/elements/kong-auth-login/KongAuthLogin.ce.vue
@@ -58,6 +58,10 @@ const props = defineProps({
     type: Boolean,
     default: false, // must be false by default
   },
+  showBasicAuthLoginLink: {
+    type: Boolean,
+    default: true, // must be true by default
+  },
   idpLoginEnabled: {
     type: Boolean,
     default: false,
@@ -94,6 +98,11 @@ provide(
 provide(
   'basic-auth-login-enabled',
   computed((): boolean => props.basicAuthLoginEnabled),
+)
+
+provide(
+  'show-basic-auth-login-link',
+  computed((): boolean => props.showBasicAuthLoginLink),
 )
 
 // IDP

--- a/src/elements/kong-auth-login/KongAuthLogin.spec.ts
+++ b/src/elements/kong-auth-login/KongAuthLogin.spec.ts
@@ -150,8 +150,41 @@ describe('KongAuthLogin.ce.vue', () => {
       },
     })
 
+    // SSO button and basic auth link should exist
+    cy.getTestId(testids.ssoBtn).should('be.visible')
+    cy.getTestId(testids.basicAuthLink).should('be.visible')
+    // Elements should not exist
+    cy.getTestId(testids.form).should('not.exist')
+    cy.getTestId(testids.submitBtn).should('not.exist')
+    cy.getTestId(testids.errorMessage).should('not.exist')
+    cy.getTestId(testids.instructionText).should('not.exist')
+    cy.getTestId(testids.forgotPasswordLink).should('not.exist')
+    cy.getTestId(testids.registerHelpText).should('not.exist')
+    cy.getTestId(testids.registerLink).should('not.exist')
+    cy.getTestId(testids.passwordResetMessage).should('not.exist')
+    cy.getTestId(testids.confirmedEmailMessage).should('not.exist')
+    cy.getTestId(testids.registerSuccessMessage).should('not.exist')
+    cy.getTestId(testids.loaderContainer).should('not.exist')
+  })
+
+  it('renders a SSO button and no basic auth form and hides the basic auth link if the `showBasicAuthLoginLink` prop is set to false', () => {
+    cy.stub(getConfigOptions, 'userEntity').returns('user')
+    const loginPath = 'test-login-path'
+    // Stub URL path
+    cy.stub(win, 'getLocationPathname').returns(`/login/${loginPath}`)
+    cy.stub(win, 'setLocationHref').as('set-location')
+    mount(KongAuthLogin, {
+      props: {
+        basicAuthLoginEnabled: false,
+        showBasicAuthLoginLink: false,
+        idpLoginEnabled: true,
+      },
+    })
+
     // SSO button should exist
     cy.getTestId(testids.ssoBtn).should('be.visible')
+    // Basic auth link should not exist
+    cy.getTestId(testids.basicAuthLink).should('not.exist')
     // Elements should not exist
     cy.getTestId(testids.form).should('not.exist')
     cy.getTestId(testids.submitBtn).should('not.exist')


### PR DESCRIPTION
## Summary

Add a new `show-basic-auth-login-link` prop to the Login form to allow force-hiding the basic authentication link.

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
