### PR TITLE
feat(idp): add callback_url [KHCP-8139]

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ The login element **must** reside at the `{window.location.origin}/login` path i
 | `basicAuthLoginEnabled` | Boolean | `false` | Enable basic auth login. **To set to false, simply do not add the prop** |
 | `showBasicAuthLoginLink` | Boolean | `true` | Show a link to log in with basic auth credentials on the IdP login form. |
 | `idpLoginEnabled` | Boolean | `false` | Enable IdP login detection. |
+| `idpLoginCallbackUrl` | URL | `''` | Set the URL to return to in order to complete the OIDC flow. In most cases, this should be set to `${window.location.origin}/login` |
 | `idpLoginReturnTo` | URL | `''` | Set the URL to return to upon successful IdP login. In most cases, this should be set to `window.location.origin` |
 
 > **Note**: When utilizing the props as a native web component, you may need to use dot syntax, as shown here

--- a/sandbox/components/ComponentsApp.vue
+++ b/sandbox/components/ComponentsApp.vue
@@ -6,8 +6,9 @@
       </h4>
       <KongAuthLogin
         basic-auth-login-enabled
+        idp-login-callback-url="http://localhost:5173/login"
         idp-login-enabled
-        idp-login-return-to="https://kompany795bb6b9.us.portal.konghq.tech"
+        idp-login-return-to="http://localhost:5173/"
         show-forgot-password-link
         @click-forgot-password-link="showAlert('User clicked forgot password')"
         @click-register-link="showAlert('User clicked register')"

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -16,7 +16,7 @@
           class="login-seo-button"
           data-testid="kong-auth-login-sso"
           :disabled="loginBtnSSODisabled"
-          @click.prevent="redirectToIdp(idpLoginReturnTo)"
+          @click.prevent="redirectToIdp(idpLoginCallbackUrl, idpLoginReturnTo)"
         >
           <KIcon
             color="currentColor"
@@ -185,6 +185,7 @@ const registerSuccessText: Ref<string> = inject('register-success-text', ref(mes
 const basicAuthLoginEnabled: Ref<boolean> = inject('basic-auth-login-enabled', ref(true))
 const showBasicAuthLoginLink: Ref<boolean> = inject('show-basic-auth-login-link', ref(true))
 const idpLoginEnabled: Ref<boolean> = inject('idp-login-enabled', ref(false))
+const idpLoginCallbackUrl: Ref<string> = inject('idp-login-callback-url', ref(''))
 const idpLoginReturnTo: Ref<string> = inject('idp-login-return-to', ref(''))
 
 const formData = reactive({
@@ -199,7 +200,7 @@ const loginDividerIsVisible = computed((): boolean => (basicAuthLoginEnabled.val
 
 // Setup and automatically trigger IDP (or ignore it, depending on the props)
 // Passing the refs on purpose so values are reactive.
-const { isIdpLogin, idpIsLoading, redirectToIdp } = useIdentityProvider(basicAuthLoginEnabled, idpLoginEnabled, idpLoginReturnTo)
+const { isIdpLogin, idpIsLoading, redirectToIdp } = useIdentityProvider(basicAuthLoginEnabled, idpLoginEnabled, idpLoginCallbackUrl, idpLoginReturnTo)
 
 // Automatically trigger state change based on IDP
 watch(idpIsLoading, (val) => {

--- a/src/composables/useIdentityProvider.ts
+++ b/src/composables/useIdentityProvider.ts
@@ -1,4 +1,4 @@
-import { onMounted, ref, Ref, watch } from 'vue'
+import { onMounted, ref, Ref, watchEffect } from 'vue'
 import useConfigOptions from '@/composables/useConfigOptions'
 import { win } from '@/utils'
 
@@ -7,7 +7,7 @@ export interface IdentityProviderComposable {
   idpIsLoading: Ref<boolean>
   shouldTriggerIdpLogin(): boolean
   shouldTriggerIdpAuthentication(): boolean
-  redirectToIdp(returnTo: string): void
+  redirectToIdp(callbackUrl: string, returnTo: string): void
   authenticateWithIdp(): void
 }
 
@@ -16,12 +16,14 @@ export interface IdentityProviderComposable {
  * @export IdentityProviderComposable
  * @param {ref<boolean>} basicAuthIsEnabled - If true, user can log in with basic auth credentials.
  * @param {ref<boolean>} idpIsEnabled - If true, automatically handle IDP in the onMounted lifecycle hook.
+ * @param {ref<string>} idpLoginCallbackUrl - Pass the OIDC callback URL; typically ends in `/login`
  * @param {ref<string>} idpLoginRedirectTo - Pass the returnTo URL.
  * @return {*} {IdentityProviderComposable}
  */
 export default function useIdentityProvider(
   basicAuthIsEnabled: Ref<boolean>,
   idpIsEnabled: Ref<boolean>,
+  idpLoginCallbackUrl: Ref<string>,
   idpLoginRedirectTo: Ref<string>,
 ): IdentityProviderComposable {
   const { apiBaseUrl, userEntity, developerConfig } = useConfigOptions()
@@ -89,7 +91,7 @@ export default function useIdentityProvider(
    * Redirect the user to the kauth/authenticate/{org-id} endpoint, and provide a returnTo path.
    * @param {string} [returnTo] - The full URL (including https://) where to return the user to with the code and state.
    */
-  const redirectToIdp = (returnTo: string): void => {
+  const redirectToIdp = (callbackUrl: string, returnTo: string): void => {
     idpIsLoading.value = true
 
     if (userEntity !== 'developer' && !organizationLoginPath.value) {
@@ -114,11 +116,39 @@ export default function useIdentityProvider(
       return
     }
 
+    // Create a URL from callbackUrl and encode for query string. Fail if not a valid URL.
+    let callbackUrlParam
+
+    try {
+      // Create new URL from callbackUrl, wrapped in try/catch to construct the URL object
+      // IMPORTANT: Fallback to `${window.location.origin}/login`
+      const oidcCallbackUrl = new URL(callbackUrl || win.getLocationOrigin() + '/login')
+
+      // Encode for query string param
+      callbackUrlParam = `callback_url=${encodeURIComponent(oidcCallbackUrl.href)}`
+    } catch (_) {
+      idpIsLoading.value = false
+      // Console warning references the element prop name instead of local variable
+      // eslint-disable-next-line no-console
+      console.error("'idpLoginCallbackUrl' must be a valid URL")
+      return
+    }
+
     // Prevent additional redirects while processing
     isRedirecting.value = true
 
+    // Create an array to hold the URL params
+    const urlParams = []
+
+    // Always add the returnTo param
+    urlParams.push(returnToParam)
+    // If `user`, add the callback_url param
+    if (userEntity === 'user') {
+      urlParams.push(callbackUrlParam)
+    }
+
     // Combine URL params, skipping any that are empty
-    const redirectParams = '?' + [returnToParam].filter(Boolean).join('&')
+    const redirectParams = '?' + urlParams.filter(Boolean).join('&')
 
     if (userEntity === 'developer') {
       if (!developerConfig?.portalId) {
@@ -204,9 +234,9 @@ export default function useIdentityProvider(
 
   // Add watcher to allow `kong-auth-login` element time to load and retrigger redirect.
   // `idp-login-return-to` prop value will likely not be available ASAP onMounted within containing app, so this will still fire.
-  watch(idpLoginRedirectTo, (loginUrl) => {
-    if (idpIsEnabled.value && !!loginUrl.trim() && shouldTriggerIdpLogin() && !isRedirecting.value) {
-      redirectToIdp(loginUrl)
+  watchEffect(() => {
+    if (idpIsEnabled.value && !!String(idpLoginRedirectTo.value || '').trim() && !!String(idpLoginCallbackUrl.value || '').trim() && shouldTriggerIdpLogin() && !isRedirecting.value) {
+      redirectToIdp(idpLoginCallbackUrl.value, idpLoginRedirectTo.value)
     }
   })
 
@@ -218,7 +248,7 @@ export default function useIdentityProvider(
 
     // Check for IDP login
     if (shouldTriggerIdpLogin()) {
-      redirectToIdp(idpLoginRedirectTo.value)
+      redirectToIdp(idpLoginCallbackUrl.value, idpLoginRedirectTo.value)
       return
     }
 

--- a/src/composables/useIdentityProvider.ts
+++ b/src/composables/useIdentityProvider.ts
@@ -1,4 +1,4 @@
-import { onMounted, ref, Ref, watchEffect } from 'vue'
+import { onMounted, ref, Ref, watch } from 'vue'
 import useConfigOptions from '@/composables/useConfigOptions'
 import { win } from '@/utils'
 
@@ -91,7 +91,7 @@ export default function useIdentityProvider(
    * Redirect the user to the kauth/authenticate/{org-id} endpoint, and provide a returnTo path.
    * @param {string} [returnTo] - The full URL (including https://) where to return the user to with the code and state.
    */
-  const redirectToIdp = (callbackUrl: string, returnTo: string): void => {
+  const redirectToIdp = (callbackUrl = '', returnTo: string): void => {
     idpIsLoading.value = true
 
     if (userEntity !== 'developer' && !organizationLoginPath.value) {
@@ -234,9 +234,9 @@ export default function useIdentityProvider(
 
   // Add watcher to allow `kong-auth-login` element time to load and retrigger redirect.
   // `idp-login-return-to` prop value will likely not be available ASAP onMounted within containing app, so this will still fire.
-  watchEffect(() => {
-    if (idpIsEnabled.value && !!String(idpLoginRedirectTo.value || '').trim() && !!String(idpLoginCallbackUrl.value || '').trim() && shouldTriggerIdpLogin() && !isRedirecting.value) {
-      redirectToIdp(idpLoginCallbackUrl.value, idpLoginRedirectTo.value)
+  watch([idpLoginRedirectTo, idpLoginCallbackUrl], ([redirectTo, callbackUrl]) => {
+    if (idpIsEnabled.value && !!String(redirectTo || '').trim() && shouldTriggerIdpLogin() && !isRedirecting.value) {
+      redirectToIdp(callbackUrl, redirectTo)
     }
   })
 

--- a/src/elements/kong-auth-login/KongAuthLogin.ce.vue
+++ b/src/elements/kong-auth-login/KongAuthLogin.ce.vue
@@ -66,6 +66,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  idpLoginCallbackUrl: {
+    type: String,
+    default: '',
+  },
   idpLoginReturnTo: {
     type: String,
     default: '',
@@ -109,6 +113,10 @@ provide(
 provide(
   'idp-login-enabled',
   computed((): boolean => props.idpLoginEnabled),
+)
+provide(
+  'idp-login-callback-url',
+  computed((): string => (props.idpLoginCallbackUrl ? props.idpLoginCallbackUrl : '')),
 )
 provide(
   'idp-login-return-to',

--- a/src/elements/kong-auth-login/KongAuthLogin.spec.ts
+++ b/src/elements/kong-auth-login/KongAuthLogin.spec.ts
@@ -501,15 +501,20 @@ describe('KongAuthLogin.ce.vue', () => {
     it("should initiate user IdP login if props are set and URL is '/login/{login-path}'", () => {
       cy.stub(getConfigOptions, 'userEntity').returns('user')
       const loginPath = 'test-login-path'
-      const redirectPath = `/authenticate/${loginPath}?returnTo=${encodeURIComponent(win.getLocationOrigin())}`
+      const callbackUrl = 'https://cloud.konghq.tech/login'
+      const redirectPath = `/authenticate/${loginPath}?returnTo=${encodeURIComponent(win.getLocationOrigin() + '/')}&callback_url=${encodeURIComponent(callbackUrl)}`
       // Stub URL path
       cy.stub(win, 'getLocationPathname').returns(`/login/${loginPath}`)
-      cy.stub(win, 'setLocationHref').as('set-location')
+      // cy.stub(win, 'setLocationHref').as('set-location')
+      cy.stub(win, 'setLocationHref', args => {
+        console.log('args', args)
+      }).as('set-location')
 
       mount(KongAuthLogin, {
         props: {
           idpLoginEnabled: true,
           idpLoginReturnTo: win.getLocationOrigin(),
+          idpLoginCallbackUrl: callbackUrl,
         },
       })
 
@@ -526,7 +531,7 @@ describe('KongAuthLogin.ce.vue', () => {
       cy.stub(win, 'getLocationPathname').returns('/login/sso')
       cy.stub(win, 'setLocationHref').as('set-location')
       // Stub URL path
-      const redirectPath = `/developer/authenticate/sso?returnTo=${encodeURIComponent(win.getLocationOrigin())}`
+      const redirectPath = `/developer/authenticate/sso?returnTo=${encodeURIComponent(win.getLocationOrigin() + '/')}`
 
       mount(KongAuthLogin, {
         props: {


### PR DESCRIPTION
## Summary

Add a new `idpLoginCallbackUrl` prop to the login element and append the `callback_url` to the `/authenticate` endpoint for the `user` IdP flow.

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [x] **Tests:** Includes any new/updated component tests
- [x] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [x] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
