### PR TITLE
chore(renovate): utilize shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,56 +1,5 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":semanticCommits",
-    ":automergeRequireAllStatusChecks",
-    ":automergePatch",
-    ":automergeMinor"
-  ],
-  "baseBranches": [
-    "main"
-  ],
-  "dependencyDashboard": true,
-  "rangeStrategy": "bump",
-  "platformAutomerge": true,
-  "labels": [
-    "dependencies",
-    "renovate-bot"
-  ],
-  "schedule": [
-    "every weekday"
-  ],
-  "timezone": "America/New_York",
-  "automergeSchedule": [
-    "every weekday"
-  ],
-  "npmrcMerge": true,
-  "minimumReleaseAge": "14 days",
-  "packageRules": [
-    {
-      "automerge": true,
-      "groupName": "all non-major dependencies with stable version",
-      "groupSlug": "all-minor-patch",
-      "matchCurrentVersion": "!/^0/",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "minimumReleaseAge": "10 days"
-    },
-    {
-      "automerge": true,
-      "groupName": "all kong scoped dependencies",
-      "groupSlug": "all-kong-scopes",
-      "matchPackagePatterns": [
-        "^@kong\/",
-        "^@kong-ui\/",
-        "^@kong-ui-public\/"
-      ],
-      "minimumReleaseAge": "2 hours"
-    }
+    "github>Kong/public-shared-renovate:kong-frontend-config.json"
   ]
 }


### PR DESCRIPTION
## Summary

Utilize a shared Renovate config

## Ready-To-Review Checklist

<!--
Is this PR ready to be reviewed?
- No: no worries, you can create it as a "draft" PR to let reviewers know and prevent accidental merges
- Yes: great! be sure to have all these checked before asking for review
-->

- [ ] **Tests:** Includes any new/updated component tests
- [ ] **Docs:** updates [documentation](https://github.com/Kong/khcp/tree/master/packages/docs) as needed
- [ ] **Commit format/atomicity:** the commits follow the guidelines [outlined here](https://github.com/Kong/kong-ee/blob/next/2.1.x.x/CONTRIBUTING.md#commit-atomicity)

## Ready-To-Merge Checklist

<!--
Is this PR ready to be merged?
- No: Once the PR is ready, ask your colleagues to review your work
- Yes: great! be sure to have all these checked before merging
-->

- [ ] **Reviewer** - At least one reviewer has reviewed the following:
  - [ ] **Functional:** reviewed acceptance criteria and functionally tested the changes
  - [ ] **Tests:** Reviewer has checked the automated tests for correctness and completeness
