### PR TITLE
fix: backwards compatibility for kalert

### DIFF
--- a/src/components/ErrorMessage.vue
+++ b/src/components/ErrorMessage.vue
@@ -4,13 +4,6 @@
     class="kong-auth-error-message error-message"
     data-testid="kong-auth-error-message"
   >
-    <template v-if="passwordRequirements.length" #default>
-      <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
-      <ul>
-        <li v-for="(error, idx) in passwordRequirements" :key="idx">{{ capitalizeFirstChar(error) }}</li>
-      </ul>
-    </template>
-    <template v-else #default>{{ errorMessage }}</template>
     <template v-if="passwordRequirements.length" #alertMessage>
       <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
       <ul>
@@ -18,6 +11,13 @@
       </ul>
     </template>
     <template v-else #alertMessage>{{ errorMessage }}</template>
+    <template v-if="passwordRequirements.length" #default>
+      <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
+      <ul>
+        <li v-for="(error, idx) in passwordRequirements" :key="idx">{{ capitalizeFirstChar(error) }}</li>
+      </ul>
+    </template>
+    <template v-else #default>{{ errorMessage }}</template>
   </KAlert>
 </template>
 

--- a/src/components/ErrorMessage.vue
+++ b/src/components/ErrorMessage.vue
@@ -11,6 +11,13 @@
       </ul>
     </template>
     <template v-else #default>{{ errorMessage }}</template>
+    <template v-if="passwordRequirements.length" #alertMessage>
+      <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
+      <ul>
+        <li v-for="(error, idx) in passwordRequirements" :key="idx">{{ capitalizeFirstChar(error) }}</li>
+      </ul>
+    </template>
+    <template v-else #alertMessage>{{ errorMessage }}</template>
   </KAlert>
 </template>
 

--- a/src/components/ErrorMessage.vue
+++ b/src/components/ErrorMessage.vue
@@ -1,16 +1,10 @@
 <template>
   <KAlert
+    :alert-message="errorMessage"
     appearance="danger"
     class="kong-auth-error-message error-message"
     data-testid="kong-auth-error-message"
   >
-    <template v-if="passwordRequirements.length" #alertMessage>
-      <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
-      <ul>
-        <li v-for="(error, idx) in passwordRequirements" :key="idx">{{ capitalizeFirstChar(error) }}</li>
-      </ul>
-    </template>
-    <template v-else #alertMessage>{{ errorMessage }}</template>
     <template v-if="passwordRequirements.length" #default>
       <p>{{ capitalizeFirstChar(errorMessage) }}:</p>
       <ul>

--- a/src/components/ErrorMessage.vue
+++ b/src/components/ErrorMessage.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- NOTE: alert-message is added for backwards compatibility of host apps that arent using kongponents alpha -->
   <KAlert
     :alert-message="errorMessage"
     appearance="danger"

--- a/src/components/ForgotPasswordForm.vue
+++ b/src/components/ForgotPasswordForm.vue
@@ -5,6 +5,7 @@
     </div>
     <div v-else-if="currentState.matches('success')">
       <KAlert
+        :alert-message="successText"
         appearance="info"
         class="form-error"
         data-testid="kong-auth-forgot-password-success-message"

--- a/src/components/ForgotPasswordForm.vue
+++ b/src/components/ForgotPasswordForm.vue
@@ -4,6 +4,7 @@
       <ErrorMessage :error="error" />
     </div>
     <div v-else-if="currentState.matches('success')">
+      <!-- NOTE: alert-message is added for backwards compatibility of host apps that arent using kongponents alpha -->
       <KAlert
         :alert-message="successText"
         appearance="info"

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -42,6 +42,7 @@
       </div>
 
       <div v-else-if="currentState.matches('reset_password')" class="form-error">
+        <!-- NOTE: alert-message is added for backwards compatibility of host apps that arent using kongponents alpha -->
         <KAlert
           :alert-message="messages.login.passwordResetSuccess"
           appearance="success"
@@ -52,6 +53,7 @@
       </div>
 
       <div v-else-if="currentState.matches('confirmed_email')" class="form-error">
+        <!-- NOTE: alert-message is added for backwards compatibility of host apps that arent using kongponents alpha -->
         <KAlert
           :alert-message="messages.login.confirmedEmailSuccess"
           appearance="success"
@@ -62,6 +64,7 @@
       </div>
 
       <div v-else-if="currentState.matches('from_register')" class="form-error">
+        <!-- NOTE: alert-message is added for backwards compatibility of host apps that arent using kongponents alpha -->
         <KAlert
           :alert-message="registerSuccessText"
           appearance="success"

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -43,6 +43,7 @@
 
       <div v-else-if="currentState.matches('reset_password')" class="form-error">
         <KAlert
+          :alert-message="messages.login.passwordResetSuccess"
           appearance="success"
           class="justify-content-center"
           data-testid="kong-auth-login-password-reset-message"
@@ -52,6 +53,7 @@
 
       <div v-else-if="currentState.matches('confirmed_email')" class="form-error">
         <KAlert
+          :alert-message="messages.login.confirmedEmailSuccess"
           appearance="success"
           class="justify-content-center"
           data-testid="kong-auth-login-confirmed-email-message"
@@ -61,6 +63,7 @@
 
       <div v-else-if="currentState.matches('from_register')" class="form-error">
         <KAlert
+          :alert-message="registerSuccessText"
           appearance="success"
           class="justify-content-center"
           data-testid="kong-auth-login-register-success-message"


### PR DESCRIPTION
# Summary
Need to add the `alert-message` prop for `konnect-portal` as that is not using kongponents alpha.
<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
