### PR TITLE
ci: renovate bot name change [TDX-6753]

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   commitlint:
-    if: ${{ github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'mend[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Publish package preview
         id: package-preview
         # Do not run for `alpha` or `beta` branches
-        if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]' && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
+        if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]' && github.actor != 'mend[bot]' && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
         env:
           GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
         run: |


### PR DESCRIPTION
# Description

Renovate is changing their Github app name https://github.com/renovatebot/renovate/discussions/37842

ticket: https://konghq.atlassian.net/browse/TDX-6753